### PR TITLE
refactor: centralize navigation items

### DIFF
--- a/components/common/Header.tsx
+++ b/components/common/Header.tsx
@@ -1,13 +1,6 @@
 "use client"
 
-import {
-  Home,
-  Heart,
-  MapPin,
-  MessageCircle,
-  LogOut,
-  User,
-} from "lucide-react"
+import { LogOut } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import Logo from "@/components/common/Logo"
 import { useRouter } from "next/navigation"
@@ -16,6 +9,7 @@ import { motion } from "framer-motion"
 import ProductSearchBar from "@/components/common/product-search-bar"
 import { usePathname } from "next/navigation"
 import { useState, useEffect } from "react"
+import { authNavItems, getGuestNavItems } from "@/components/navigation/nav-items"
 
 interface HeaderProps {
   searchQuery?: string
@@ -46,19 +40,7 @@ export default function Header({
   const router = useRouter()
   const pathname = usePathname()
 
-  const navItems = isLoggedIn
-    ? [
-      { id: "home", icon: Home, label: "Inicio", path: "/" },
-      { id: "favorites", icon: Heart, label: "Favoritos", path: "/favorites" },
-      { id: "map", icon: MapPin, label: "Mapa", path: "/map" },
-      { id: "messages", icon: MessageCircle, label: "Mensajes", path: "/messages" },
-      { id: "profile", icon: User, label: "Mi Perfil", path: "/profile" },
-    ]
-    : [
-      { id: "home", icon: Home, label: "Inicio", path: "/" },
-      { id: "map", icon: MapPin, label: "Mapa", path: "/map" },
-      { id: "profile", icon: User, label: "Iniciar sesión", path: "/login" },
-    ]
+  const navItems = isLoggedIn ? authNavItems : getGuestNavItems("Iniciar sesión")
 
   const currentActive = navItems.find(item => pathname === item.path)?.id || "home"
 

--- a/components/navigation/BottomNavigationBar.tsx
+++ b/components/navigation/BottomNavigationBar.tsx
@@ -3,8 +3,8 @@
 import { motion } from "framer-motion"
 import { useEffect, useState } from "react"
 import { useRouter, usePathname } from "next/navigation"
-import { Home, Heart, MapPin, MessageCircle, User } from "lucide-react"
 import { useAuth } from "@/context/AuthContext"
+import { authNavItems, getGuestNavItems } from "./nav-items"
 
 interface BottomNavigationBarProps {
     activeScreen: string
@@ -23,19 +23,7 @@ export default function BottomNavigationBar({
     const [hidden, setHidden] = useState(false)
     const [lastScrollY, setLastScrollY] = useState(0)
 
-    const navItems = isLoggedIn
-        ? [
-            { id: "home", icon: Home, label: "Inicio", path: "/" },
-            { id: "favorites", icon: Heart, label: "Favoritos", path: "/favorites" },
-            { id: "map", icon: MapPin, label: "Mapa", path: "/map" },
-            { id: "messages", icon: MessageCircle, label: "Mensajes", path: "/messages" },
-            { id: "profile", icon: User, label: "Perfil ", path: "/profile" },
-        ]
-        : [
-            { id: "home", icon: Home, label: "Inicio", path: "/" },
-            { id: "map", icon: MapPin, label: "Mapa", path: "/map" },
-            { id: "profile", icon: User, label: "Acceso", path: "/login" },
-        ]
+    const navItems = isLoggedIn ? authNavItems : getGuestNavItems()
 
     const currentActive = navItems.find((item) => pathname === item.path)?.id || "home"
 

--- a/components/navigation/FloatingNavigation.tsx
+++ b/components/navigation/FloatingNavigation.tsx
@@ -2,8 +2,8 @@
 
 import { useRouter, usePathname } from 'next/navigation'
 import { motion } from "framer-motion"
-import { Home, Heart, MapPin, MessageCircle, User } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { authNavItems } from "./nav-items"
 
 interface FloatingNavigationProps {
   activeScreen: string
@@ -22,13 +22,7 @@ export default function FloatingNavigation({
     return null
   }
 
-  const navItems = [
-    { id: "home", icon: Home, label: "Inicio", path: "/" },
-    { id: "favorites", icon: Heart, label: "Favoritos", path: "/favorites" },
-    { id: "map", icon: MapPin, label: "Mapa", path: "/map" },
-    { id: "messages", icon: MessageCircle, label: "Mensajes", path: "/messages" },
-    { id: "profile", icon: User, label: "Perfil", path: "/profile" },
-  ]
+  const navItems = authNavItems
 
   const handleClick = (id: string, path: string) => {
     onScreenChange(id)

--- a/components/navigation/nav-items.ts
+++ b/components/navigation/nav-items.ts
@@ -1,0 +1,22 @@
+import { type LucideIcon, Home, Heart, MapPin, MessageCircle, User } from "lucide-react"
+
+export interface NavItem {
+  id: string
+  icon: LucideIcon
+  label: string
+  path: string
+}
+
+export const authNavItems: NavItem[] = [
+  { id: "home", icon: Home, label: "Inicio", path: "/" },
+  { id: "favorites", icon: Heart, label: "Favoritos", path: "/favorites" },
+  { id: "map", icon: MapPin, label: "Mapa", path: "/map" },
+  { id: "messages", icon: MessageCircle, label: "Mensajes", path: "/messages" },
+  { id: "profile", icon: User, label: "Perfil", path: "/profile" },
+]
+
+export const getGuestNavItems = (profileLabel = "Acceso"): NavItem[] => [
+  { id: "home", icon: Home, label: "Inicio", path: "/" },
+  { id: "map", icon: MapPin, label: "Mapa", path: "/map" },
+  { id: "profile", icon: User, label: profileLabel, path: "/login" },
+]


### PR DESCRIPTION
## Summary
- centralize navigation items in shared module
- use shared navigation across header and navigation components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689364e28ea4832b8901fa1dd0d430e9